### PR TITLE
Vagrant: Remove jmods folder from Test JDK derivation in VPC tests

### DIFF
--- a/ansible/pbTestScripts/testJDK.sh
+++ b/ansible/pbTestScripts/testJDK.sh
@@ -7,7 +7,7 @@ if [[ "$(uname)" == "FreeBSD" ]]; then
 	export TEST_JDK_HOME=$HOME/jdk
 else
 	ls -ld $HOME/openjdk-build/workspace/build/src/build/*/images/jdk*
- 	export TEST_JDK_HOME=$(ls -1d $HOME/openjdk-build/workspace/build/src/build/*/images/jdk* |egrep -v 'jre|-image|static-libs|sbom')
+ 	export TEST_JDK_HOME=$(ls -1d $HOME/openjdk-build/workspace/build/src/build/*/images/jdk* |egrep -v 'jre|-image|static-libs|sbom|-jmods')
 fi
 
 echo DEBUG: TEST_JDK_HOME = $TEST_JDK_HOME

--- a/ansible/pbTestScripts/testJDKWin.sh
+++ b/ansible/pbTestScripts/testJDKWin.sh
@@ -12,7 +12,7 @@ rm -rf /cygdrive/c/tmp/*-test-image
 
 # Set Test JDK HOME To The Relocated JDK
 # export TEST_JDK_HOME=C:/cygwin64$(find ~ -maxdepth 1 -type d -name "*jdk*"|grep -v ".*jre"| grep -v ".*-image")
-export TEST_JDK_HOME=`ls -d c:/tmp/jdk*|grep -v "static"|grep -v "debug"|grep -v "jre"|grep -v "test-image"`
+export TEST_JDK_HOME=`ls -d c:/tmp/jdk*|grep -v "static"|grep -v "debug"|grep -v "jre"|grep -v "test-image"|grep -v "-jmods"`
 echo TEST_JDK_HOME=$TEST_JDK_HOME
 
 ## Run The Same Tests As Test JDK for Linux


### PR DESCRIPTION
Fix a bug where the addition of a new folder into the JDK build folder structure is causing the VPC post build tests to fail, as the derivation of the JDK folder was finding 2 entries.

:heavy_check_mark: Ubuntu.24.04 - VPC: https://ci.adoptium.net/job/VagrantPlaybookCheck/2095/
:hourglass_flowing_sand:  https://ci.adoptium.net/job/VagrantPlaybookCheck/2096/


##### Checklist
<!-- For completed items, change [ ] to [x]. Delete any lines that are not applicable for this PR -->

- [X] commit message has one of the [standard prefixes](https://github.com/adoptium/infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [X] playbook changes run through [VPC](https://ci.adoptium.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptium.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
